### PR TITLE
Created authentication check middleware 

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -8,7 +8,7 @@ const isAuthenticated = function (
   if (req.isAuthenticated()) {
     return next();
   }
-  res.status(401).send("Unauthenticated user").redirect("/login");
+  res.status(401).send({ message: "Unauthenticated user" });
 };
 
 export default isAuthenticated;

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,10 +1,14 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response, NextFunction } from "express";
 
-const isAuthenticated = function (req: Request, res: Response, next: NextFunction) {
-    if (req.isAuthenticated()) {
-        return next();
-    }
-    res.status(401).send("Unauthenticated user").redirect('/login');
-}
+const isAuthenticated = function (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+  res.status(401).send("Unauthenticated user").redirect("/login");
+};
 
 export default isAuthenticated;

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express';
+
+const isAuthenticated = function (req: Request, res: Response, next: NextFunction) {
+    if (req.isAuthenticated()) {
+        return next();
+    }
+    res.status(401).send("Unauthenticated user").redirect('/login');
+}
+
+export default isAuthenticated;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import passport from "passport";
 import User from "../models/user";
 import { Strategy as LocalStrategy } from "passport-local";
+import isAuthenticated from "../middleware/auth";
 
 const router = Router();
 
@@ -47,7 +48,7 @@ router.post("/login", passport.authenticate("local"), (req, res) => {
   res.send("Login successful");
 });
 
-router.post("/logout", (req, res) => {
+router.post("/logout", isAuthenticated, (req, res) => {
   req.logout((err) => {
     if (err) {
       res.status(500).send("Failed to log out");


### PR DESCRIPTION
-Closes #5 
-For routes requiring authentication, can use the isAuthenticated function from /middleware/auth
-There's an error with using both res.status.send and redirect("/login"), not sure which one would be better