### PR TITLE
allow studies to have multiple variants

### DIFF
--- a/packages/api/src/models/study.ts
+++ b/packages/api/src/models/study.ts
@@ -13,14 +13,18 @@ export interface ISession {
   name: string;
   tasks: ITaskInstance[];
 }
+export interface IStudyVariant {
+  name: string;
+  sessions: ISession[];
+}
 
 export interface IStudy {
   name: string;
   description: string;
   batteries: Types.ObjectId[];
-  sessions: ISession[];
   owner: Types.ObjectId;
   serverCode: string;
+  variants: IStudyVariant[];
 }
 
 const taskInstanceSchema = new Schema<ITaskInstance>({
@@ -37,13 +41,18 @@ const sessionSchema = new Schema<ISession>({
   tasks: [taskInstanceSchema],
 });
 
+const variantSchema = new Schema<IStudyVariant>({
+  name: { type: String, default: "" },
+  sessions: [sessionSchema],
+});
+
 const studySchema = new Schema<IStudy>({
   name: { type: String, default: "" },
   description: { type: String, default: "" },
   batteries: [{ type: Schema.Types.ObjectId, ref: "CustomizedBattery" }],
-  sessions: [sessionSchema],
   owner: { type: Schema.Types.ObjectId, ref: "User", required: true },
   serverCode: { type: String, unique: true },
+  variants: { type: [variantSchema], default: [{ name: "", sessions: [] }] },
 });
 
 studySchema.pre("save", async function (next) {

--- a/packages/ui/src/api/studies.ts
+++ b/packages/ui/src/api/studies.ts
@@ -31,6 +31,11 @@ export interface ISession {
   tasks: ITaskInstance[];
 }
 
+export interface IStudyVariant {
+  name: string;
+  sessions: ISession[];
+}
+
 export interface ICustomizedBattery {
   _id: string;
   battery: string;
@@ -42,8 +47,8 @@ export interface GetStudyResponse {
   name: string;
   description: string;
   batteries: ICustomizedBattery[];
-  sessions: ISession[];
   serverCode: string;
+  variants: IStudyVariant[];
 }
 async function getStudies() {
   const response = await axiosInstance.get<GetStudyResponse[]>("/studies/");

--- a/packages/ui/src/stores/studyBuilder.ts
+++ b/packages/ui/src/stores/studyBuilder.ts
@@ -93,10 +93,11 @@ export const useStudyBuilderStore = defineStore("studyBuilder", () => {
         });
         taskBank.value = studyData.batteries.map((b) => b._id);
         sessionData.value = {};
-        studyData.sessions.forEach((s) => {
+        studyData.variants[0].sessions.forEach((s) => {
+          // TODO: map per variant later on
           sessionData.value[s._id] = s;
         });
-        sessions.value = studyData.sessions.map((s) => s._id);
+        sessions.value = studyData.variants[0].sessions.map((s) => s._id); // TODO: map per variant later on
         isStudyLoading.value = false;
         serverCode.value = studyData.serverCode;
       })
@@ -194,8 +195,13 @@ export const useStudyBuilderStore = defineStore("studyBuilder", () => {
       name: name.value ?? "",
       description: description.value ?? "",
       batteries: taskBank.value.map((id) => taskData.value[id]), // TODO: fix this
-      sessions: sessions.value.map((id) => sessionData.value[id]),
       serverCode: serverCode.value,
+      variants: [
+        {
+          name: name.value ?? "",
+          sessions: sessions.value.map((id) => sessionData.value[id]),
+        },
+      ],
     });
   }
 


### PR DESCRIPTION
# Changes

* Added the variant datatype so that a study can have multiple variants, which can each have multiple sessions
* Fixed up the existing backend code dependent on the former data structure to be compatible with variants
* Updated the frontend code to also have variants (UI only shows the first variant)

Closes #83