### PR TITLE
unique prefix server code 

### DIFF
--- a/packages/api/src/routes/studies.route.ts
+++ b/packages/api/src/routes/studies.route.ts
@@ -81,7 +81,7 @@ router.delete(
 router.post(
   "/:studyId/validate-prefix-server-code",
   isAuthenticated,
-  route((req) =>
+  authRoute((req) =>
     studyService.validateAndUpdatePrefixServerCode(
       req.params.studyId,
       req.body.prefixServerCode

--- a/packages/api/src/routes/studies.route.ts
+++ b/packages/api/src/routes/studies.route.ts
@@ -78,4 +78,15 @@ router.delete(
   )
 );
 
+router.post(
+  "/:studyId/validate-prefix-server-code",
+  isAuthenticated,
+  route((req) =>
+    studyService.validateAndUpdatePrefixServerCode(
+      req.params.studyId,
+      req.body.prefixServerCode
+    )
+  )
+);
+
 export default router;

--- a/packages/api/src/services/admin.service.ts
+++ b/packages/api/src/services/admin.service.ts
@@ -11,7 +11,7 @@ import type {
   ICustomizedBattery,
   IUser,
 } from "@seitz/shared";
-import { parseVisibility } from "@/util/validation.utils";
+import { parseVisibility } from "../util/validation.utils";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/api/src/util/study.utils.ts
+++ b/packages/api/src/util/study.utils.ts
@@ -1,0 +1,18 @@
+import { Study } from "../models/study";
+import { uid } from "../models/study";
+
+export async function generateUniquePrefixServerCode(): Promise<string> {
+  let newPrefix = uid.rnd(3);
+  let attempts = 0;
+
+  // try to find a unique prefix (with a limit on attempts to prevent infinite loops)
+  while (attempts < 10) {
+    const existingStudy = await Study.findOne({ prefixServerCode: newPrefix });
+    if (!existingStudy) break;
+
+    newPrefix = uid.rnd(3);
+    attempts++;
+  }
+
+  return newPrefix;
+}

--- a/packages/api/src/util/validation.utils.ts
+++ b/packages/api/src/util/validation.utils.ts
@@ -1,4 +1,4 @@
-import { VisibilityError } from "@/types/errors";
+import { VisibilityError } from "../types/errors";
 
 export enum Visibility {
   ON = "on",

--- a/packages/shared/types/api/studies.ts
+++ b/packages/shared/types/api/studies.ts
@@ -7,7 +7,7 @@ type ListStudy = Pick<IStudy, "_id" | "name" | "description">;
 
 export type GETStudy = Pick<
   IStudy,
-  "_id" | "name" | "description" | "owner" | "variants"
+  "_id" | "name" | "description" | "owner" | "variants" | "prefixServerCode"
 > & {
   batteries: GETCustomizedTask[];
 };
@@ -16,7 +16,10 @@ export type GETStudies = ListStudy[];
 
 // TODO: refine this type
 export type PUTStudy = DTO<
-  Pick<IStudy, "_id" | "name" | "description" | "owner" | "variants"> & {
+  Pick<
+    IStudy,
+    "_id" | "name" | "description" | "owner" | "variants" | "prefixServerCode"
+  > & {
     batteries: GETCustomizedTask[];
   }
 >;

--- a/packages/shared/types/models/study.ts
+++ b/packages/shared/types/models/study.ts
@@ -34,6 +34,7 @@ export interface CreateStudy {
   description?: string;
   batteries?: Types.ObjectId[];
   owner: Types.ObjectId;
+  prefixServerCode: string;
   variants: CreateStudyVariant[];
 }
 


### PR DESCRIPTION
Adds a prefix server code field to the study model 

Updated previous routes to check for validation for uniqueness

updated pre save hook to now generate a new prefix if previous documents didn't have it

created endpoint for validate and save feature when editing a prefix server code