### PR TITLE
Make name not required when creating an account (bug fix)

### DIFF
--- a/packages/api/src/models/user.ts
+++ b/packages/api/src/models/user.ts
@@ -4,7 +4,12 @@ import bcrypt from "bcrypt";
 import { Role, type IUser } from "@seitz/shared";
 
 const userSchema = new Schema<IUser>({
-  name: { type: String, required: true, unique: false },
+  name: {
+    type: String,
+    required: function () {
+      return this.verified === true;
+    },
+  },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   role: {


### PR DESCRIPTION
- Bug found when creating a new account
- Error: "User validation failed: name: Path name is required."
- Hot fix: making name not required when creating an account but requiring later on.
- Will add UI components to account creation to include name but hot fix for now to be able to create accounts