### PR TITLE
Added required name field to create account page

### DIFF
--- a/packages/api/src/services/auth.service.ts
+++ b/packages/api/src/services/auth.service.ts
@@ -40,12 +40,16 @@ passport.deserializeUser((id, done) =>
 );
 
 export const signUp = async (req: any, res: any, next: any): Promise<void> => {
-  const { email, password } = req.body;
-  if (typeof email !== "string" || typeof password !== "string") {
-    next(new HttpError(400, "Must have fields email and password"));
+  const { name, email, password } = req.body;
+  if (
+    typeof email !== "string" ||
+    typeof password !== "string" ||
+    typeof name !== "string"
+  ) {
+    next(new HttpError(400, "Must have fields name, email, and password"));
   } else {
     const token = crypto.randomBytes(20).toString("hex");
-    User.create({ email, password, token })
+    User.create({ name, email, password, token })
       .then(async (user) => {
         sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
         const URL = `http://localhost:4000/auth/verify/${user.token}`;

--- a/packages/ui/src/components/AuthForm.vue
+++ b/packages/ui/src/components/AuthForm.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { ElNotification } from "element-plus";
 
 const props = defineProps({
+  hasName: Boolean,
   hasPasswordConfirm: Boolean,
   headerText: {
     type: String,
@@ -17,6 +18,7 @@ const props = defineProps({
 const emit = defineEmits(["submitted"]);
 
 const loginData = ref({
+  name: "",
   email: "",
   password: "",
   passwordConfirm: "",
@@ -47,6 +49,9 @@ function submit() {
     Welcome to the Brain Game Center
     <div class="p-2"></div>
     <ElForm label-position="top" @submit.prevent="submit">
+      <ElFormItem v-if="hasName" label="Name">
+        <ElInput v-model="loginData.name" />
+      </ElFormItem>
       <ElFormItem label="Email">
         <ElInput v-model="loginData.email" />
       </ElFormItem>

--- a/packages/ui/src/components/AuthSignupForm.vue
+++ b/packages/ui/src/components/AuthSignupForm.vue
@@ -42,6 +42,7 @@ const { mutate } = useMutation<void, AxiosError<Error>, SignupDTO>({
 
 <template>
   <AuthForm
+    has-name
     has-password-confirm
     header-text="Create your account"
     submit-text="Sign Up"


### PR DESCRIPTION
- Added a name input field to the account creation page
- Linked the field to the name attribute in the database during user registration
- An error is thrown if the name field is empty on submission

Testing:
1. Created a new account without a name --> Threw an error about the name field, unsuccessful login
2. Created a new account with a name --> Successful login, checked that user was added to database with name field being the entered value
3. Login using newly created account --> Successful login 
4. Create a new account with a name but without an email, password, or different passwords --> Threw the corresponding error, unsuccessful login
5. Check login form --> Name field does not display

